### PR TITLE
Added REUSE for GalleryTab and fixed some swiftlint issues

### DIFF
--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 637867499T;
+				DEVELOPMENT_TEAM = 4KPMYP5D54;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Allergy/Supporting Files/Info.plist";
@@ -585,7 +585,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2023.allergy;
+				PRODUCT_BUNDLE_IDENTIFIER = AndyWang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 4KPMYP5D54;
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Allergy/Supporting Files/Info.plist";
@@ -585,7 +585,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = AndyWang;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2023.allergy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Allergy/GalleryTab/GalleryLister.swift
+++ b/Allergy/GalleryTab/GalleryLister.swift
@@ -31,7 +31,11 @@ class GalleryLister: ObservableObject {
                 print("Error while retrieving file: ", error)
             }
             
-            for item in result!.items {
+            guard let result else {
+                return
+            }
+            
+            for item in result.items {
                 let pictureRef = storageRef.child(item.name)
                 pictureRef.getData(maxSize: 10 * 1024 * 1024) { data, error in
                     if let error = error {

--- a/Allergy/GalleryTab/GalleryLister.swift
+++ b/Allergy/GalleryTab/GalleryLister.swift
@@ -14,29 +14,19 @@ import SwiftUI
 
 
 class GalleryLister: ObservableObject {
-    @Published var images: Dictionary<String, UIImage> = [:]
-    //var initializedEmulator = false
+    @Published var images: [String: UIImage] = [:]
     
 
-    
     func listImages(subfolder: String) {
-        //let id = UUID().uuidString
         let storage = Storage.storage()
-        
-//        if !initializedEmulator && FeatureFlags.useFirebaseEmulator {
-//            storage.useEmulator(withHost: "localhost", port: 9199)
-//            initializedEmulator = true
-//        }
         
         guard let userId = Auth.auth().currentUser?.uid else {
             fatalError("Uploading image without user authenticated ...")
         }
         
         let storageRef = storage.reference().child("users/\(userId)/\(subfolder)")
-        //let metadata = StorageMetadata()
-        //metadata.contentType = "image/jpg"
         
-        storageRef.listAll { (result, error) in
+        storageRef.listAll { result, error in
             if let error = error {
                 print("Error while retrieving file: ", error)
             }

--- a/Allergy/GalleryTab/GalleryTab.swift
+++ b/Allergy/GalleryTab/GalleryTab.swift
@@ -1,8 +1,9 @@
 //
-//  GalleryTab.swift
-//  Allergy
+// This source file is part of the CS342 2023 Allergy Team Application project
 //
-//  Created by Andy Wang on 3/2/23.
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
 //
 
 import AllergySchedule
@@ -19,7 +20,6 @@ struct GalleryTab: View {
                 }
             }.navigationTitle("Gallery")
         }
-        
     }
 }
 

--- a/Allergy/GalleryTab/GalleryViewList.swift
+++ b/Allergy/GalleryTab/GalleryViewList.swift
@@ -30,6 +30,7 @@ struct GalleryViewList: View {
                            .resizable()
                            .scaledToFit()
                            .frame(width: 100)
+                           .accessibility(hidden: true)
                    }
                }
            }

--- a/Allergy/Home.swift
+++ b/Allergy/Home.swift
@@ -47,7 +47,6 @@ struct HomeView: View {
                 .tabItem {
                     Label("GALLERYVIEW_TAB_TITLE", systemImage: "list.clipboard")
                 }
-            
         }
     }
 }

--- a/AllergyModules/Package.swift
+++ b/AllergyModules/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "AllergyMockDataStorageProvider", targets: ["AllergyMockDataStorageProvider"]),
         .library(name: "AllergyOnboardingFlow", targets: ["AllergyOnboardingFlow"]),
         .library(name: "AllergySchedule", targets: ["AllergySchedule"]),
-        .library(name: "AllergySharedContext", targets: ["AllergySharedContext"]),
+        .library(name: "AllergySharedContext", targets: ["AllergySharedContext"])
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordBDHG/CardinalKit", .upToNextMinor(from: "0.3.3")),
@@ -82,6 +82,6 @@ let package = Package(
         .target(
             name: "AllergySharedContext",
             dependencies: []
-        ),
+        )
     ]
 )


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

## :bulb: Proposed solution
Fixed some of the github REUSE and swiftlint checks from PR #16.

### Reviewer Nudging
@PSchmiedmayer there is a force unwrapping violation in line 34 of GalleryLister.swift and I'm not quite sure how to handle it, as optional variables are still pretty new to me. (Removing the ! results in a build error..) Some help or guidance for this issue would be appreciated!

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

