### PR TITLE
Gallery View Improvements

### DIFF
--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* AllergyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* AllergyTests.swift */; };
 		653A256C28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256B28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift */; };
+		A1F3B7B529BA6A5500C3D6A8 /* IndividualPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F3B7B429BA6A5500C3D6A8 /* IndividualPhotoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		653A256728338800005D4D48 /* AllergyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AllergyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A256B28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerAndQuestionnaireTests.swift; sourceTree = "<group>"; };
 		653A258928339462005D4D48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1F3B7B429BA6A5500C3D6A8 /* IndividualPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndividualPhotoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +135,7 @@
 				2F28D06929B5770700C923DA /* GalleryTab.swift */,
 				2F28D06A29B5770700C923DA /* GalleryLister.swift */,
 				2F28D06B29B5770700C923DA /* GalleryViewList.swift */,
+				A1F3B7B429BA6A5500C3D6A8 /* IndividualPhotoView.swift */,
 			);
 			path = GalleryTab;
 			sourceTree = "<group>";
@@ -395,6 +398,7 @@
 			files = (
 				2F28D06D29B5770700C923DA /* GalleryLister.swift in Sources */,
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
+				A1F3B7B529BA6A5500C3D6A8 /* IndividualPhotoView.swift in Sources */,
 				2F4E23832989D51F0013F3D9 /* AllergyAppTestingSetup.swift in Sources */,
 				2F28D06C29B5770700C923DA /* GalleryTab.swift in Sources */,
 				2F5E32BD297E05EA003432F8 /* AllergyAppDelegate.swift in Sources */,

--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2F28D06D29B5770700C923DA /* GalleryLister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F28D06A29B5770700C923DA /* GalleryLister.swift */; };
 		2F28D06E29B5770700C923DA /* GalleryViewList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F28D06B29B5770700C923DA /* GalleryViewList.swift */; };
 		2F39333329A89EB50035A05C /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39333229A89EB50035A05C /* FirebaseFirestore */; };
+		2F455E5B29BAD32C005FCB42 /* FirestoreConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F455E5A29BAD32C005FCB42 /* FirestoreConfiguration.swift */; };
 		2F49B7762980407C00BCB272 /* CardinalKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7752980407B00BCB272 /* CardinalKit */; };
 		2F49B7782980407C00BCB272 /* FHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7772980407C00BCB272 /* FHIR */; };
 		2F49B77A2980407C00BCB272 /* HealthKitDataSource in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7792980407C00BCB272 /* HealthKitDataSource */; };
@@ -64,6 +65,7 @@
 		2F28D06929B5770700C923DA /* GalleryTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryTab.swift; sourceTree = "<group>"; };
 		2F28D06A29B5770700C923DA /* GalleryLister.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryLister.swift; sourceTree = "<group>"; };
 		2F28D06B29B5770700C923DA /* GalleryViewList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryViewList.swift; sourceTree = "<group>"; };
+		2F455E5A29BAD32C005FCB42 /* FirestoreConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreConfiguration.swift; sourceTree = "<group>"; };
 		2F49B77329803E8F00BCB272 /* AllergyModules */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AllergyModules; sourceTree = "<group>"; };
 		2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		2F4E23822989D51F0013F3D9 /* AllergyAppTestingSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllergyAppTestingSetup.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 			children = (
 				2F28D06829B5770700C923DA /* GalleryTab */,
 				653A2550283387FE005D4D48 /* Allergy.swift */,
+				2F455E5A29BAD32C005FCB42 /* FirestoreConfiguration.swift */,
 				2F5E32BC297E05EA003432F8 /* AllergyAppDelegate.swift */,
 				2F4E23822989D51F0013F3D9 /* AllergyAppTestingSetup.swift */,
 				2FC975A72978F11A00BA99FE /* Home.swift */,
@@ -404,6 +407,7 @@
 				2F5E32BD297E05EA003432F8 /* AllergyAppDelegate.swift in Sources */,
 				653A2551283387FE005D4D48 /* Allergy.swift in Sources */,
 				2F28D06E29B5770700C923DA /* GalleryViewList.swift in Sources */,
+				2F455E5B29BAD32C005FCB42 /* FirestoreConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Allergy/AllergyAppDelegate.swift
+++ b/Allergy/AllergyAppDelegate.swift
@@ -15,7 +15,6 @@ import FHIRToFirestoreAdapter
 import FirebaseAccount
 import class FirebaseFirestore.FirestoreSettings
 import FirebaseStorage
-import FirebaseConfiguration
 import FirestoreDataStorage
 import FirestoreStoragePrefixUserIdAdapter
 import HealthKit
@@ -77,16 +76,3 @@ class AllergyAppDelegate: CardinalKitAppDelegate {
         }
     }
 }
-
-
-class FirestoreStorage<ComponentStandard: Standard>: Component {
-     @Dependency private var configureFirebaseApp: ConfigureFirebaseApp
-
-
-     func configure() {
-         let storage = Storage.storage()
-         if FeatureFlags.useFirebaseEmulator {
-             storage.useEmulator(withHost: "localhost", port: 9199)
-         }
-     }
- }

--- a/Allergy/AllergyAppDelegate.swift
+++ b/Allergy/AllergyAppDelegate.swift
@@ -14,6 +14,8 @@ import FHIR
 import FHIRToFirestoreAdapter
 import FirebaseAccount
 import class FirebaseFirestore.FirestoreSettings
+import FirebaseStorage
+import FirebaseConfiguration
 import FirestoreDataStorage
 import FirestoreStoragePrefixUserIdAdapter
 import HealthKit
@@ -34,6 +36,7 @@ class AllergyAppDelegate: CardinalKitAppDelegate {
                 } else {
                     FirebaseAccountConfiguration()
                 }
+                FirestoreStorage()
                 firestore
             }
             if HKHealthStore.isHealthDataAvailable() {
@@ -74,3 +77,16 @@ class AllergyAppDelegate: CardinalKitAppDelegate {
         }
     }
 }
+
+
+class FirestoreStorage<ComponentStandard: Standard>: Component {
+     @Dependency private var configureFirebaseApp: ConfigureFirebaseApp
+
+
+     func configure() {
+         let storage = Storage.storage()
+         if FeatureFlags.useFirebaseEmulator {
+             storage.useEmulator(withHost: "localhost", port: 9199)
+         }
+     }
+ }

--- a/Allergy/FirestoreConfiguration.swift
+++ b/Allergy/FirestoreConfiguration.swift
@@ -1,0 +1,25 @@
+//
+// This source file is part of the CS342 2023 Allergy Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import AllergySharedContext
+import CardinalKit
+import FirebaseConfiguration
+import FirebaseStorage
+
+
+class FirestoreStorage<ComponentStandard: Standard>: Component {
+     @Dependency private var configureFirebaseApp: ConfigureFirebaseApp
+
+
+     func configure() {
+         let storage = Storage.storage()
+         if FeatureFlags.useFirebaseEmulator {
+             storage.useEmulator(withHost: "localhost", port: 9199)
+         }
+     }
+ }

--- a/Allergy/GalleryTab/GalleryViewList.swift
+++ b/Allergy/GalleryTab/GalleryViewList.swift
@@ -16,9 +16,7 @@ import SwiftUI
 
 struct GalleryViewList: View {
     let photoUploadContext: PhotoUploadContext
-    let storage = Storage.storage()
     @ObservedObject var galleryLister = GalleryLister()
-    @State var selectedImage: UIImage?
     
     let rows = [GridItem(.fixed(100))]
     
@@ -32,9 +30,6 @@ struct GalleryViewList: View {
                             .scaledToFit()
                             .frame(width: 100)
                             .accessibilityHidden(true)
-                    }
-                    .task {
-                        selectedImage = image
                     }
                 }
             }

--- a/Allergy/GalleryTab/GalleryViewList.swift
+++ b/Allergy/GalleryTab/GalleryViewList.swift
@@ -22,27 +22,27 @@ struct GalleryViewList: View {
     
     let rows = [GridItem(.fixed(100))]
     
-       var body: some View {
-           ScrollView(.horizontal) {
-               LazyHGrid(rows: rows) {
-                   ForEach(Array(galleryLister.images.values), id: \.self) { image in
-                       NavigationLink(destination: IndividualPhotoView(photo: $selectedImage)) {
-                           Image(uiImage: image)
-                               .resizable()
-                               .scaledToFit()
-                               .frame(width: 100)
-                               .accessibilityHidden(true)
-                       }
-                       .task {
-                           selectedImage = image
-                       }
-                   }
-               }
-           }
-           .task {
-               galleryLister.listImages(subfolder: photoUploadContext.rawValue)
-           }
-       }
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHGrid(rows: rows) {
+                ForEach(Array(galleryLister.images.values), id: \.self) { image in
+                    NavigationLink(destination: IndividualPhotoView(photo: image)) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 100)
+                            .accessibilityHidden(true)
+                    }
+                    .task {
+                        selectedImage = image
+                    }
+                }
+            }
+        }
+        .task {
+            galleryLister.listImages(subfolder: photoUploadContext.rawValue)
+        }
+    }
 }
 
 // struct GalleryViewList_Previews: PreviewProvider {

--- a/Allergy/GalleryTab/GalleryViewList.swift
+++ b/Allergy/GalleryTab/GalleryViewList.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-
 import AllergySchedule
 import FirebaseAuth
 import FirebaseCore
@@ -19,6 +18,7 @@ struct GalleryViewList: View {
     let photoUploadContext: PhotoUploadContext
     let storage = Storage.storage()
     @ObservedObject var galleryLister = GalleryLister()
+    @State var selectedImage: UIImage?
     
     let rows = [GridItem(.fixed(100))]
     
@@ -26,11 +26,16 @@ struct GalleryViewList: View {
            ScrollView(.horizontal) {
                LazyHGrid(rows: rows) {
                    ForEach(Array(galleryLister.images.values), id: \.self) { image in
-                        Image(uiImage: image)
-                           .resizable()
-                           .scaledToFit()
-                           .frame(width: 100)
-                           .accessibility(hidden: true)
+                       NavigationLink(destination: IndividualPhotoView(photo: $selectedImage)) {
+                           Image(uiImage: image)
+                               .resizable()
+                               .scaledToFit()
+                               .frame(width: 100)
+                               .accessibilityHidden(true)
+                       }
+                       .task {
+                           selectedImage = image
+                       }
                    }
                }
            }
@@ -40,8 +45,8 @@ struct GalleryViewList: View {
        }
 }
 
-struct GalleryViewList_Previews: PreviewProvider {
-    static var previews: some View {
-        GalleryViewList(photoUploadContext: .base)
-    }
-}
+// struct GalleryViewList_Previews: PreviewProvider {
+//     static var previews: some View {
+//         GalleryViewList(photoUploadContext: .base)
+//     }
+// }

--- a/Allergy/GalleryTab/IndividualPhotoView.swift
+++ b/Allergy/GalleryTab/IndividualPhotoView.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the CS342 2023 Allergy Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct IndividualPhotoView: View {
+    @Binding var photo: UIImage?
+    
+    var body: some View {
+        Image(uiImage: photo!)
+            .resizable()
+            .scaledToFit()
+            .padding()
+            .accessibilityHidden(true)
+    }
+}
+
+// struct IndividualPhotoView_Previews: PreviewProvider {
+//     static var previews: some View {
+//         IndividualPhotoView()
+//     }
+// }

--- a/Allergy/GalleryTab/IndividualPhotoView.swift
+++ b/Allergy/GalleryTab/IndividualPhotoView.swift
@@ -9,19 +9,14 @@
 import SwiftUI
 
 struct IndividualPhotoView: View {
-    var photo: UIImage?
+    var photo: UIImage
+    
     
     var body: some View {
-        Image(uiImage: photo!)
+        Image(uiImage: photo)
             .resizable()
             .scaledToFit()
             .padding()
             .accessibilityHidden(true)
     }
 }
-
-// struct IndividualPhotoView_Previews: PreviewProvider {
-//     static var previews: some View {
-//         IndividualPhotoView()
-//     }
-// }

--- a/Allergy/GalleryTab/IndividualPhotoView.swift
+++ b/Allergy/GalleryTab/IndividualPhotoView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct IndividualPhotoView: View {
-    @Binding var photo: UIImage?
+    var photo: UIImage?
     
     var body: some View {
         Image(uiImage: photo!)

--- a/AllergyModules/Sources/AllergySchedule/StorageManager.swift
+++ b/AllergyModules/Sources/AllergySchedule/StorageManager.swift
@@ -14,17 +14,11 @@ import FirebaseStorage
 
 class StorageManager {
     static let shared = StorageManager()
-    var initializedEmulator = false
     
     
     func uploadImage(_ data: Data, subfolder: String, comment: String) {
         let id = UUID().uuidString
         let storage = Storage.storage()
-        
-        if !initializedEmulator && FeatureFlags.useFirebaseEmulator {
-            storage.useEmulator(withHost: "localhost", port: 9199)
-            initializedEmulator = true
-        }
         
         guard let userId = Auth.auth().currentUser?.uid else {
             fatalError("Uploading image without user authenticated ...")

--- a/storage.rules
+++ b/storage.rules
@@ -1,3 +1,4 @@
+rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Gallery View Improvements

## :recycle: Current situation & Problem
Currently the pictures shown in the gallery view are very small and cannot be magnified.

## :bulb: Proposed solution
Embedded the images in a navigationlink that links to a separate view that displays the full-size image.

### Reviewer Nudging
@PSchmiedmayer I had to use an optional variable for the state and binding in GalleryViewList.swift and IndividualPhotoView.swift to pass the images or else I got a bunch of errors (not really sure why), but that is causing me a swiftlint error when I force unwrap `photo` in IndividualPhotoView. I tried implementing a guard statement but I'm not really sure how to get it working in this context.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

