### PR TITLE
Decrease image upload compression quality

### DIFF
--- a/AllergyModules/Sources/AllergySchedule/PhotoUploadView.swift
+++ b/AllergyModules/Sources/AllergySchedule/PhotoUploadView.swift
@@ -30,7 +30,7 @@ struct PhotoUploadView: View {
                     .border(.blue)
                 Button("Upload") {
                     guard let image,
-                          let data = image.jpegData(compressionQuality: 0.8) else {
+                          let data = image.jpegData(compressionQuality: 0.4) else {
                         return
                     }
                     


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

## :recycle: Current situation & Problem
Bandwidth usage is too high. Partially combat this by decreasing file sizes.

## :bulb: Proposed solution
Change compression quality from 0.8 to 0.4.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

