### PR TITLE
Merge ui-tests 

### DIFF
--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		2F9056E8299E266B003D3802 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2F9056E6299E266B003D3802 /* GoogleService-Info.plist */; };
 		2FC9759F2978E39600BA99FE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2FC9759E2978E39600BA99FE /* Localizable.strings */; };
 		2FC975A82978F11A00BA99FE /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC975A72978F11A00BA99FE /* Home.swift */; };
+		312646FD29BE930F000B8638 /* GalleryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312646FB29BE930F000B8638 /* GalleryViewTests.swift */; };
+		312646FE29BE930F000B8638 /* PhotoUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312646FC29BE930F000B8638 /* PhotoUploadTests.swift */; };
 		653A2551283387FE005D4D48 /* Allergy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A2550283387FE005D4D48 /* Allergy.swift */; };
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* AllergyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* AllergyTests.swift */; };
@@ -75,6 +77,8 @@
 		2FC94CD4298B0A1D009C8209 /* Allergy.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Allergy.xctestplan; sourceTree = "<group>"; };
 		2FC9759E2978E39600BA99FE /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		2FC975A72978F11A00BA99FE /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
+		312646FB29BE930F000B8638 /* GalleryViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryViewTests.swift; sourceTree = "<group>"; };
+		312646FC29BE930F000B8638 /* PhotoUploadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoUploadTests.swift; sourceTree = "<group>"; };
 		653A254D283387FE005D4D48 /* Allergy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Allergy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A2550283387FE005D4D48 /* Allergy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Allergy.swift; sourceTree = "<group>"; };
 		653A255428338800005D4D48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -202,6 +206,8 @@
 		653A256A28338800005D4D48 /* AllergyUITests */ = {
 			isa = PBXGroup;
 			children = (
+				312646FC29BE930F000B8638 /* PhotoUploadTests.swift */,
+				312646FB29BE930F000B8638 /* GalleryViewTests.swift */,
 				2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */,
 				653A256B28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift */,
 			);
@@ -423,8 +429,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				312646FD29BE930F000B8638 /* GalleryViewTests.swift in Sources */,
 				2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */,
 				653A256C28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift in Sources */,
+				312646FE29BE930F000B8638 /* PhotoUploadTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -568,7 +576,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = "637867499T";
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Allergy/Supporting Files/Info.plist";

--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -576,7 +576,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 6A7V727ALP;
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Allergy/Supporting Files/Info.plist";
@@ -601,7 +601,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "Stanley-Yang";
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2023.allergy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Allergy.xcodeproj/project.pbxproj
+++ b/Allergy.xcodeproj/project.pbxproj
@@ -576,7 +576,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 637867499T;
+				DEVELOPMENT_TEAM = 6A7V727ALP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Allergy/Supporting Files/Info.plist";
@@ -601,7 +601,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2023.allergy;
+				PRODUCT_BUNDLE_IDENTIFIER = "Stanley-Yang";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Allergy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Allergy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -102,7 +102,7 @@
     {
       "identity" : "imagesource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordBDHG/ImageSource",
+      "location" : "https://github.com/StanfordBDHG/ImageSource.git",
       "state" : {
         "revision" : "d6d035913d6becc602487aaeaa48a3b8a46afd32"
       }

--- a/Allergy/GalleryTab/GalleryViewList.swift
+++ b/Allergy/GalleryTab/GalleryViewList.swift
@@ -23,13 +23,13 @@ struct GalleryViewList: View {
     var body: some View {
         ScrollView(.horizontal) {
             LazyHGrid(rows: rows) {
-                ForEach(Array(galleryLister.images.values), id: \.self) { image in
-                    NavigationLink(destination: IndividualPhotoView(photo: image)) {
-                        Image(uiImage: image)
+                ForEach(Array(galleryLister.images.values.enumerated()), id: \.offset) { image in
+                    NavigationLink(destination: IndividualPhotoView(photo: image.element)) {
+                        Image(uiImage: image.element)
                             .resizable()
                             .scaledToFit()
+                            .accessibilityLabel(Text("\(photoUploadContext.rawValue)-\(image.offset)"))
                             .frame(width: 100)
-                            .accessibilityHidden(true)
                     }
                 }
             }
@@ -39,9 +39,3 @@ struct GalleryViewList: View {
         }
     }
 }
-
-// struct GalleryViewList_Previews: PreviewProvider {
-//     static var previews: some View {
-//         GalleryViewList(photoUploadContext: .base)
-//     }
-// }

--- a/AllergyModules/Sources/AllergySchedule/AllergyImageSource.swift
+++ b/AllergyModules/Sources/AllergySchedule/AllergyImageSource.swift
@@ -120,6 +120,7 @@ public struct AllergyImageSource: View {
                         .foregroundColor(.clear)
                         .frame(width: proxy.size.width, height: proxy.size.height)
                     Image(systemName: "plus")
+                        .accessibilityLabel(Text("Add Image"))
                 }
             }
         )

--- a/AllergyModules/Sources/AllergySchedule/AllergyTaskContext.swift
+++ b/AllergyModules/Sources/AllergySchedule/AllergyTaskContext.swift
@@ -8,6 +8,7 @@
 
 import FHIR
 
+
 public enum PhotoUploadContext: String, Codable, CaseIterable {
     case base
     case day0
@@ -15,6 +16,8 @@ public enum PhotoUploadContext: String, Codable, CaseIterable {
     case day4
     case optional
 }
+
+
 /// The context attached to each task in the CS342 2023 Allergy Team Application.
 public enum AllergyTaskContext: Codable, Identifiable {
     case questionnaire(Questionnaire)

--- a/AllergyUITests/GalleryViewTests.swift
+++ b/AllergyUITests/GalleryViewTests.swift
@@ -22,7 +22,6 @@ class GalleryViewTests: XCTestCase {
     }
     
     
-    // swiftlint:disable:next function_body_length
     func testGalleryView() throws {
                 let app = XCUIApplication()
                 XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
@@ -40,12 +39,5 @@ class GalleryViewTests: XCTestCase {
                 let app = XCUIApplication()
                 XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                
-
-
-        
-        
-
     }
-    
 }

--- a/AllergyUITests/GalleryViewTests.swift
+++ b/AllergyUITests/GalleryViewTests.swift
@@ -26,11 +26,11 @@ class GalleryViewTests: XCTestCase {
                 let app = XCUIApplication()
                 XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                XCTAssertTrue(app.staticTexts["base"].waitForExistence(timeout: 2))
                 XCTAssertTrue(app.staticTexts["day0"].waitForExistence(timeout: 2))
                 XCTAssertTrue(app.staticTexts["day2"].waitForExistence(timeout: 2))
-                XCTAssertTrue(app.staticTexts["day4"].waitForExistence(timeout: 2))
-                XCTAssertTrue(app.staticTexts["base"].waitForExistence(timeout: 2))
                 app.swipeUp()
+                XCTAssertTrue(app.staticTexts["day4"].waitForExistence(timeout: 2))
                 XCTAssertTrue(app.staticTexts["optional"].waitForExistence(timeout: 2))
     }
     

--- a/AllergyUITests/GalleryViewTests.swift
+++ b/AllergyUITests/GalleryViewTests.swift
@@ -16,28 +16,28 @@ class GalleryViewTests: XCTestCase {
         
         continueAfterFailure = false
         
+        try disablePasswordAutofill()
+        
         let app = XCUIApplication()
-        app.launchArguments = ["--skipOnboarding"]
+        app.launchArguments = ["--showOnboarding"]
         app.deleteAndLaunch(withSpringboardAppName: "Allergy")
+        
+        try app.conductOnboardingIfNeeded()
     }
     
     
     func testGalleryView() throws {
-                let app = XCUIApplication()
-                XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                XCTAssertTrue(app.staticTexts["base"].waitForExistence(timeout: 2))
-                XCTAssertTrue(app.staticTexts["day0"].waitForExistence(timeout: 2))
-                XCTAssertTrue(app.staticTexts["day2"].waitForExistence(timeout: 2))
-                app.swipeUp()
-                XCTAssertTrue(app.staticTexts["day4"].waitForExistence(timeout: 2))
-                XCTAssertTrue(app.staticTexts["optional"].waitForExistence(timeout: 2))
-    }
-    
-    
-    func testPhotoUpload() throws {
-                let app = XCUIApplication()
-                XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+        let app = XCUIApplication()
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
+        app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+        
+        
+        XCTAssertTrue(app.staticTexts["base"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["day0"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["day2"].waitForExistence(timeout: 2))
+        app.swipeUp()
+        
+        XCTAssertTrue(app.staticTexts["day4"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["optional"].waitForExistence(timeout: 2))
     }
 }

--- a/AllergyUITests/GalleryViewTests.swift
+++ b/AllergyUITests/GalleryViewTests.swift
@@ -1,8 +1,9 @@
 //
-//  GalleryViewTests.swift
-//  AllergyUITests
+// This source file is part of the CS342 2023 Allergy Team Application project
 //
-//  Created by Rachel Wu on 3/6/23.
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
 //
 
 import XCTest

--- a/AllergyUITests/GalleryViewTests.swift
+++ b/AllergyUITests/GalleryViewTests.swift
@@ -1,0 +1,50 @@
+//
+//  GalleryViewTests.swift
+//  AllergyUITests
+//
+//  Created by Rachel Wu on 3/6/23.
+//
+
+import XCTest
+import XCTestExtensions
+
+
+class GalleryViewTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.launchArguments = ["--skipOnboarding"]
+        app.deleteAndLaunch(withSpringboardAppName: "Allergy")
+    }
+    
+    
+    // swiftlint:disable:next function_body_length
+    func testGalleryView() throws {
+                let app = XCUIApplication()
+                XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                XCTAssertTrue(app.staticTexts["day0"].waitForExistence(timeout: 2))
+                XCTAssertTrue(app.staticTexts["day2"].waitForExistence(timeout: 2))
+                XCTAssertTrue(app.staticTexts["day4"].waitForExistence(timeout: 2))
+                XCTAssertTrue(app.staticTexts["base"].waitForExistence(timeout: 2))
+                app.swipeUp()
+                XCTAssertTrue(app.staticTexts["optional"].waitForExistence(timeout: 2))
+    }
+    
+    
+    func testPhotoUpload() throws {
+                let app = XCUIApplication()
+                XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Gallery"].waitForExistence(timeout: 2))
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                
+
+
+        
+        
+
+    }
+    
+}

--- a/AllergyUITests/OnboardingTests.swift
+++ b/AllergyUITests/OnboardingTests.swift
@@ -34,7 +34,7 @@ class OnboardingTests: XCTestCase {
         let tabBar = app.tabBars["Tab Bar"]
         XCTAssertTrue(tabBar.buttons["Schedule"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Contacts"].waitForExistence(timeout: 2))
-        XCTAssertTrue(tabBar.buttons["Mock Upload"].waitForExistence(timeout: 2))
+        XCTAssertTrue(tabBar.buttons["Gallery"].waitForExistence(timeout: 2))
     }
 }
 

--- a/AllergyUITests/OnboardingTests.swift
+++ b/AllergyUITests/OnboardingTests.swift
@@ -33,7 +33,8 @@ class OnboardingTests: XCTestCase {
         
         let tabBar = app.tabBars["Tab Bar"]
         XCTAssertTrue(tabBar.buttons["Schedule"].waitForExistence(timeout: 2))
-        XCTAssertTrue(tabBar.buttons["Contacts"].waitForExistence(timeout: 2))
+        XCTAssertTrue(tabBar.buttons["Instructions"].waitForExistence(timeout: 2))
+        XCTAssertTrue(tabBar.buttons["Mock Upload"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Gallery"].waitForExistence(timeout: 2))
     }
 }

--- a/AllergyUITests/OnboardingTests.swift
+++ b/AllergyUITests/OnboardingTests.swift
@@ -34,7 +34,6 @@ class OnboardingTests: XCTestCase {
         let tabBar = app.tabBars["Tab Bar"]
         XCTAssertTrue(tabBar.buttons["Schedule"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Instructions"].waitForExistence(timeout: 2))
-        XCTAssertTrue(tabBar.buttons["Mock Upload"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Gallery"].waitForExistence(timeout: 2))
     }
 }

--- a/AllergyUITests/OnboardingTests.swift
+++ b/AllergyUITests/OnboardingTests.swift
@@ -29,7 +29,7 @@ class OnboardingTests: XCTestCase {
     func testOnboardingFlow() throws {
         let app = XCUIApplication()
         
-                try app.navigateOnboardingFlow()
+        try app.navigateOnboardingFlow()
         
         let tabBar = app.tabBars["Tab Bar"]
         XCTAssertTrue(tabBar.buttons["Schedule"].waitForExistence(timeout: 2))
@@ -41,7 +41,7 @@ class OnboardingTests: XCTestCase {
 
 extension XCUIApplication {
     func conductOnboardingIfNeeded() throws {
-        if self.staticTexts["CardinalKit\nAllergy Application"].waitForExistence(timeout: 2) {
+        if self.staticTexts["Allergy Patch Testing"].waitForExistence(timeout: 2) {
             try navigateOnboardingFlow()
         }
     }

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -58,7 +58,8 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Photo Two Days After Removal",
             image: "Photo, August 08, 2012, 2:55 PM",
             comment: "Testing!",
-            index: 7
+            index: 7,
+            scrollDown: true
         )
         
         // Optional
@@ -66,14 +67,15 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Optional Photo",
             image: "Photo, August 08, 2012, 2:55 PM",
             comment: "Testing!",
-            index: 7
+            index: 9,
+            scrollDown: true
         )
     }
 }
 
 
 extension XCUIApplication {
-    func investigateUploadImage(task: String, image: String, comment: String, index: Int) {
+    func investigateUploadImage(task: String, image: String, comment: String, index: Int, scrollDown: Bool = false) {
         tabBars["Tab Bar"].buttons["Schedule"].tap()
         swipeUp(velocity: .slow)
         uploadImage(task: task, image: image, comment: comment)
@@ -81,7 +83,7 @@ extension XCUIApplication {
         // Switch to gallery tab to check for existence of photo and text
         tabBars["Tab Bar"].buttons["Gallery"].tap()
         
-        if !collectionViews.children(matching: .cell).element(boundBy: index).isHittable {
+        if scrollDown {
             swipeUp(velocity: .slow)
         }
         
@@ -90,7 +92,8 @@ extension XCUIApplication {
             collectionViews
                 .children(matching: .cell)
                 .element(boundBy: index)
-                .scrollViews.children(matching: .other)
+                .scrollViews
+                .children(matching: .other)
                 .element(boundBy: 0)
                 .children(matching: .other)
                 .element
@@ -99,11 +102,11 @@ extension XCUIApplication {
     }
     
     func uploadImage(task: String, image: String, comment: String) {
-        var takePhotoStaticText = staticTexts[task]
+        let takePhotoStaticText = staticTexts[task]
         XCTAssertTrue(takePhotoStaticText.waitForExistence(timeout: 2))
         takePhotoStaticText.tap()
         
-        let addButton = images["Add"]
+        let addButton = buttons["Add Image"]
         XCTAssertTrue(addButton.waitForExistence(timeout: 2))
         addButton.tap()
         

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -10,7 +10,6 @@ import XCTestExtensions
 import XCTHealthKit
 
 
-
 class PhotoUploadTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -27,12 +26,12 @@ class PhotoUploadTests: XCTestCase {
             func testPhotoUpload() throws {
                 
                 let app = XCUIApplication()
-                let takePhotoStaticText = app.collectionViews.children(matching: .cell).element(boundBy: 2).staticTexts["Take Photo"]
+                var takePhotoStaticText = app.collectionViews.staticTexts["Take Baseline Photo"]
                 takePhotoStaticText.tap()
                 app.buttons["Add"].tap()
                 // Picks photo
                 app.collectionViews.buttons["Photo Picker"].tap()
-                let testPhoto = "Photo, March 12, 2011, 4:17 PM"
+                var testPhoto = "Photo, March 12, 2011, 4:17 PM"
                 app.scrollViews.otherElements.images[testPhoto].tap()
         
                 // Enters a comment
@@ -44,7 +43,102 @@ class PhotoUploadTests: XCTestCase {
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
                 
                 // Check for existence of photo
-                app.images[testPhoto].exists
+                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 1).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                
+                // Day 0
+                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
+                app.swipeUp()
+                takePhotoStaticText = app.collectionViews/*@START_MENU_TOKEN@*/.staticTexts["Take Photo After Application"]/*[[".cells.staticTexts[\"Take Photo After Application\"]",".staticTexts[\"Take Photo After Application\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+                takePhotoStaticText.tap()
+                app.buttons["Add"].tap()
+                // Picks photo
+                app.collectionViews.buttons["Photo Picker"].tap()
+                testPhoto = "Photo, August 08, 2012, 2:29 PM"
+                app.scrollViews.otherElements.images[testPhoto].tap()
+        
+                // Enters a comment
+                app.textFields["Enter a comment (optional)"].tap()
+                app.textFields["Enter a comment (optional)"].typeText("Testing!")
+                // Upload photo
+                app.buttons["Upload"].tap()
+                
+                // Switch to gallery tab to check for existence of photo and text
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                
+                // Check for existence of photo
+                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 3).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+            
+                // DAY 2
+                
+                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
+                app.swipeUp()
+                takePhotoStaticText = app.collectionViews.staticTexts["Take Photo Two Days After Application"]
+                takePhotoStaticText.tap()
+                app.buttons["Add"].tap()
+                // Picks photo
+                app.collectionViews.buttons["Photo Picker"].tap()
+                testPhoto = "Photo, October 09, 2009, 2:09 PM"
+                app.scrollViews.otherElements.images[testPhoto].tap()
+        
+                // Enters a comment
+                app.textFields["Enter a comment (optional)"].tap()
+                app.textFields["Enter a comment (optional)"].typeText("Testing!")
+                // Upload photo
+                app.buttons["Upload"].tap()
+                
+                // Switch to gallery tab to check for existence of photo and text
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                
+                // Check for existence of photo
+                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 5).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                // DAY 4
+                
+                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
+                app.swipeUp()
+                takePhotoStaticText = app.collectionViews.staticTexts["Take Photo Two Days After Removal"]
+                takePhotoStaticText.tap()
+                app.buttons["Add"].tap()
+                // Picks photo
+                app.collectionViews.buttons["Photo Picker"].tap()
+                testPhoto = "Photo, August 08, 2012, 2:55 PM"
+                app.scrollViews.otherElements.images[testPhoto].tap()
+        
+                // Enters a comment
+                app.textFields["Enter a comment (optional)"].tap()
+                app.textFields["Enter a comment (optional)"].typeText("Testing!")
+                // Upload photo
+                app.buttons["Upload"].tap()
+                
+                // Switch to gallery tab to check for existence of photo and text
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                
+                // Check for existence of photo
+                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 7).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                
+                
+                // Optional
+                
+                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
+                app.swipeUp()
+                takePhotoStaticText = app.collectionViews.staticTexts["Take Optional Photo"]
+                takePhotoStaticText.tap()
+                app.buttons["Add"].tap()
+                // Picks photo
+                app.collectionViews.buttons["Photo Picker"].tap()
+                testPhoto = "Photo, August 08, 2012, 2:55 PM"
+                app.scrollViews.otherElements.images[testPhoto].tap()
+        
+                // Enters a comment
+                app.textFields["Enter a comment (optional)"].tap()
+                app.textFields["Enter a comment (optional)"].typeText("Testing!")
+                // Upload photo
+                app.buttons["Upload"].tap()
+                
+                // Switch to gallery tab to check for existence of photo and text
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                
+                
+                                
                 
     }
 }

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -25,9 +25,9 @@ class PhotoUploadTests: XCTestCase {
     
     // swiftlint:disable:next function_body_length
             func testPhotoUpload() throws {
-                
                 let app = XCUIApplication()
-                var takePhotoStaticText = app.collectionViews.staticTexts["Take Baseline Photo"]
+                let collectionView = app.collectionViews
+                var takePhotoStaticText = collectionView.staticTexts["Take Baseline Photo"]
                 takePhotoStaticText.tap()
                 app.buttons["Add"].tap()
                 // Picks photo
@@ -44,12 +44,19 @@ class PhotoUploadTests: XCTestCase {
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
                 
                 // Check for existence of photo
-                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 1).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                let galleryViewChildren = collectionView.children(matching: .cell)
+                XCTAssertTrue(galleryViewChildren
+                    .element(boundBy: 1)
+                    .scrollViews.children(matching: .other)
+                    .element(boundBy: 0)
+                    .children(matching: .other)
+                    .element.exists)
                 
                 // Day 0
                 app.tabBars["Tab Bar"].buttons["Schedule"].tap()
                 app.swipeUp()
-                takePhotoStaticText = app.collectionViews/*@START_MENU_TOKEN@*/.staticTexts["Take Photo After Application"]/*[[".cells.staticTexts[\"Take Photo After Application\"]",".staticTexts[\"Take Photo After Application\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+                takePhotoStaticText = collectionView
+                    .staticTexts["Take Photo After Application"]
                 takePhotoStaticText.tap()
                 app.buttons["Add"].tap()
                 // Picks photo
@@ -67,7 +74,12 @@ class PhotoUploadTests: XCTestCase {
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
                 
                 // Check for existence of photo
-                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 3).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                XCTAssertTrue(galleryViewChildren
+                    .element(boundBy: 3)
+                    .scrollViews.children(matching: .other)
+                    .element(boundBy: 0)
+                    .children(matching: .other)
+                    .element.exists)
             
                 // DAY 2
                 
@@ -91,7 +103,13 @@ class PhotoUploadTests: XCTestCase {
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
                 
                 // Check for existence of photo
-                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 5).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                XCTAssertTrue(galleryViewChildren
+                    .element(boundBy: 5)
+                    .scrollViews.children(matching: .other)
+                    .element(boundBy: 0)
+                    .children(matching: .other)
+                    .element.exists)
+                
                 // DAY 4
                 
                 app.tabBars["Tab Bar"].buttons["Schedule"].tap()
@@ -114,7 +132,12 @@ class PhotoUploadTests: XCTestCase {
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
                 
                 // Check for existence of photo
-                XCTAssertTrue(app.collectionViews.children(matching: .cell).element(boundBy: 7).scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element.exists)
+                XCTAssertTrue(galleryViewChildren
+                    .element(boundBy: 7)
+                    .scrollViews.children(matching: .other)
+                    .element(boundBy: 0)
+                    .children(matching: .other)
+                    .element.exists)
                 
                 
                 // Optional
@@ -137,10 +160,5 @@ class PhotoUploadTests: XCTestCase {
                 
                 // Switch to gallery tab to check for existence of photo and text
                 app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                
-                
-                                
-                
     }
 }
-

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -1,8 +1,9 @@
 //
-//  GalleryViewTests.swift
-//  AllergyUITests
+// This source file is part of the CS342 2023 Allergy Team Application project
 //
-//  Created by Rachel Wu on 3/6/23.
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
 //
 
 import XCTest

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -1,0 +1,51 @@
+//
+//  GalleryViewTests.swift
+//  AllergyUITests
+//
+//  Created by Rachel Wu on 3/6/23.
+//
+
+import XCTest
+import XCTestExtensions
+import XCTHealthKit
+
+
+
+class PhotoUploadTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.launchArguments = ["--skipOnboarding"]
+        app.deleteAndLaunch(withSpringboardAppName: "Allergy")
+    }
+    
+    
+    // swiftlint:disable:next function_body_length
+            func testPhotoUpload() throws {
+                
+                let app = XCUIApplication()
+                let takePhotoStaticText = app.collectionViews.children(matching: .cell).element(boundBy: 2).staticTexts["Take Photo"]
+                takePhotoStaticText.tap()
+                app.buttons["Add"].tap()
+                // Picks photo
+                app.collectionViews.buttons["Photo Picker"].tap()
+                let testPhoto = "Photo, March 12, 2011, 4:17 PM"
+                app.scrollViews.otherElements.images[testPhoto].tap()
+        
+                // Enters a comment
+                app.textFields["Enter a comment (optional)"].tap()
+                app.textFields["Enter a comment (optional)"].typeText("Testing!")
+                // Upload photo
+                app.buttons["Upload"].tap()
+                // Switch to gallery tab to check for existence of photo and text
+                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+                
+                // Check for existence of photo
+                app.images[testPhoto].exists
+                
+    }
+}
+

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -34,7 +34,7 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Baseline Photo",
             image: "Photo, March 12, 2011, 4:17 PM",
             comment: "Testing!",
-            index: 1
+            testImageName: "base-0"
         )
         
         // Day 0
@@ -42,7 +42,7 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Photo After Application",
             image: "Photo, August 08, 2012, 2:29 PM",
             comment: "Testing!",
-            index: 3
+            testImageName: "day0-0"
         )
         
         // DAY 2
@@ -50,7 +50,7 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Photo Two Days After Application",
             image: "Photo, October 09, 2009, 2:09 PM",
             comment: "Testing!",
-            index: 5
+            testImageName: "day2-0"
         )
         
         // DAY 4
@@ -58,8 +58,8 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Photo Two Days After Removal",
             image: "Photo, August 08, 2012, 2:55 PM",
             comment: "Testing!",
-            index: 7,
-            scrollDown: true
+            testImageName: "day4-0",
+            testScrollDown: true
         )
         
         // Optional
@@ -67,38 +67,25 @@ class PhotoUploadTests: XCTestCase {
             task: "Take Optional Photo",
             image: "Photo, August 08, 2012, 2:55 PM",
             comment: "Testing!",
-            index: 9,
-            scrollDown: true
+            testImageName: "optional-0",
+            testScrollDown: true
         )
     }
 }
 
 
 extension XCUIApplication {
-    func investigateUploadImage(task: String, image: String, comment: String, index: Int, scrollDown: Bool = false) {
+    func investigateUploadImage(task: String, image: String, comment: String, testImageName: String, testScrollDown: Bool = false) {
         tabBars["Tab Bar"].buttons["Schedule"].tap()
         swipeUp(velocity: .slow)
         uploadImage(task: task, image: image, comment: comment)
         
-        // Switch to gallery tab to check for existence of photo and text
         tabBars["Tab Bar"].buttons["Gallery"].tap()
-        
-        if scrollDown {
+        if testScrollDown {
             swipeUp(velocity: .slow)
         }
         
-        // Check for existence of photo
-        XCTAssertTrue(
-            collectionViews
-                .children(matching: .cell)
-                .element(boundBy: index)
-                .scrollViews
-                .children(matching: .other)
-                .element(boundBy: 0)
-                .children(matching: .other)
-                .element
-                .waitForExistence(timeout: 2)
-        )
+        XCTAssert(collectionViews.scrollViews.otherElements.buttons[testImageName].waitForExistence(timeout: 2))
     }
     
     func uploadImage(task: String, image: String, comment: String) {

--- a/AllergyUITests/PhotoUploadTests.swift
+++ b/AllergyUITests/PhotoUploadTests.swift
@@ -14,151 +14,111 @@ import XCTHealthKit
 class PhotoUploadTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        
+
         continueAfterFailure = false
-        
+        try disablePasswordAutofill()
+
         let app = XCUIApplication()
-        app.launchArguments = ["--skipOnboarding"]
+        app.launchArguments = ["--showOnboarding"]
         app.deleteAndLaunch(withSpringboardAppName: "Allergy")
+
+        try app.conductOnboardingIfNeeded()
     }
     
     
-    // swiftlint:disable:next function_body_length
-            func testPhotoUpload() throws {
-                let app = XCUIApplication()
-                let collectionView = app.collectionViews
-                var takePhotoStaticText = collectionView.staticTexts["Take Baseline Photo"]
-                takePhotoStaticText.tap()
-                app.buttons["Add"].tap()
-                // Picks photo
-                app.collectionViews.buttons["Photo Picker"].tap()
-                var testPhoto = "Photo, March 12, 2011, 4:17 PM"
-                app.scrollViews.otherElements.images[testPhoto].tap()
+    func testPhotoUpload() throws {
+        let app = XCUIApplication()
         
-                // Enters a comment
-                app.textFields["Enter a comment (optional)"].tap()
-                app.textFields["Enter a comment (optional)"].typeText("Testing!")
-                // Upload photo
-                app.buttons["Upload"].tap()
-                // Switch to gallery tab to check for existence of photo and text
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                
-                // Check for existence of photo
-                let galleryViewChildren = collectionView.children(matching: .cell)
-                XCTAssertTrue(galleryViewChildren
-                    .element(boundBy: 1)
-                    .scrollViews.children(matching: .other)
-                    .element(boundBy: 0)
-                    .children(matching: .other)
-                    .element.exists)
-                
-                // Day 0
-                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
-                app.swipeUp()
-                takePhotoStaticText = collectionView
-                    .staticTexts["Take Photo After Application"]
-                takePhotoStaticText.tap()
-                app.buttons["Add"].tap()
-                // Picks photo
-                app.collectionViews.buttons["Photo Picker"].tap()
-                testPhoto = "Photo, August 08, 2012, 2:29 PM"
-                app.scrollViews.otherElements.images[testPhoto].tap()
+        // Baseline
+        app.investigateUploadImage(
+            task: "Take Baseline Photo",
+            image: "Photo, March 12, 2011, 4:17 PM",
+            comment: "Testing!",
+            index: 1
+        )
         
-                // Enters a comment
-                app.textFields["Enter a comment (optional)"].tap()
-                app.textFields["Enter a comment (optional)"].typeText("Testing!")
-                // Upload photo
-                app.buttons["Upload"].tap()
-                
-                // Switch to gallery tab to check for existence of photo and text
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                
-                // Check for existence of photo
-                XCTAssertTrue(galleryViewChildren
-                    .element(boundBy: 3)
-                    .scrollViews.children(matching: .other)
-                    .element(boundBy: 0)
-                    .children(matching: .other)
-                    .element.exists)
-            
-                // DAY 2
-                
-                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
-                app.swipeUp()
-                takePhotoStaticText = app.collectionViews.staticTexts["Take Photo Two Days After Application"]
-                takePhotoStaticText.tap()
-                app.buttons["Add"].tap()
-                // Picks photo
-                app.collectionViews.buttons["Photo Picker"].tap()
-                testPhoto = "Photo, October 09, 2009, 2:09 PM"
-                app.scrollViews.otherElements.images[testPhoto].tap()
+        // Day 0
+        app.investigateUploadImage(
+            task: "Take Photo After Application",
+            image: "Photo, August 08, 2012, 2:29 PM",
+            comment: "Testing!",
+            index: 3
+        )
         
-                // Enters a comment
-                app.textFields["Enter a comment (optional)"].tap()
-                app.textFields["Enter a comment (optional)"].typeText("Testing!")
-                // Upload photo
-                app.buttons["Upload"].tap()
-                
-                // Switch to gallery tab to check for existence of photo and text
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                
-                // Check for existence of photo
-                XCTAssertTrue(galleryViewChildren
-                    .element(boundBy: 5)
-                    .scrollViews.children(matching: .other)
-                    .element(boundBy: 0)
-                    .children(matching: .other)
-                    .element.exists)
-                
-                // DAY 4
-                
-                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
-                app.swipeUp()
-                takePhotoStaticText = app.collectionViews.staticTexts["Take Photo Two Days After Removal"]
-                takePhotoStaticText.tap()
-                app.buttons["Add"].tap()
-                // Picks photo
-                app.collectionViews.buttons["Photo Picker"].tap()
-                testPhoto = "Photo, August 08, 2012, 2:55 PM"
-                app.scrollViews.otherElements.images[testPhoto].tap()
+        // DAY 2
+        app.investigateUploadImage(
+            task: "Take Photo Two Days After Application",
+            image: "Photo, October 09, 2009, 2:09 PM",
+            comment: "Testing!",
+            index: 5
+        )
         
-                // Enters a comment
-                app.textFields["Enter a comment (optional)"].tap()
-                app.textFields["Enter a comment (optional)"].typeText("Testing!")
-                // Upload photo
-                app.buttons["Upload"].tap()
-                
-                // Switch to gallery tab to check for existence of photo and text
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
-                
-                // Check for existence of photo
-                XCTAssertTrue(galleryViewChildren
-                    .element(boundBy: 7)
-                    .scrollViews.children(matching: .other)
-                    .element(boundBy: 0)
-                    .children(matching: .other)
-                    .element.exists)
-                
-                
-                // Optional
-                
-                app.tabBars["Tab Bar"].buttons["Schedule"].tap()
-                app.swipeUp()
-                takePhotoStaticText = app.collectionViews.staticTexts["Take Optional Photo"]
-                takePhotoStaticText.tap()
-                app.buttons["Add"].tap()
-                // Picks photo
-                app.collectionViews.buttons["Photo Picker"].tap()
-                testPhoto = "Photo, August 08, 2012, 2:55 PM"
-                app.scrollViews.otherElements.images[testPhoto].tap()
+        // DAY 4
+        app.investigateUploadImage(
+            task: "Take Photo Two Days After Removal",
+            image: "Photo, August 08, 2012, 2:55 PM",
+            comment: "Testing!",
+            index: 7
+        )
         
-                // Enters a comment
-                app.textFields["Enter a comment (optional)"].tap()
-                app.textFields["Enter a comment (optional)"].typeText("Testing!")
-                // Upload photo
-                app.buttons["Upload"].tap()
-                
-                // Switch to gallery tab to check for existence of photo and text
-                app.tabBars["Tab Bar"].buttons["Gallery"].tap()
+        // Optional
+        app.investigateUploadImage(
+            task: "Take Optional Photo",
+            image: "Photo, August 08, 2012, 2:55 PM",
+            comment: "Testing!",
+            index: 7
+        )
+    }
+}
+
+
+extension XCUIApplication {
+    func investigateUploadImage(task: String, image: String, comment: String, index: Int) {
+        tabBars["Tab Bar"].buttons["Schedule"].tap()
+        swipeUp(velocity: .slow)
+        uploadImage(task: task, image: image, comment: comment)
+        
+        // Switch to gallery tab to check for existence of photo and text
+        tabBars["Tab Bar"].buttons["Gallery"].tap()
+        
+        if !collectionViews.children(matching: .cell).element(boundBy: index).isHittable {
+            swipeUp(velocity: .slow)
+        }
+        
+        // Check for existence of photo
+        XCTAssertTrue(
+            collectionViews
+                .children(matching: .cell)
+                .element(boundBy: index)
+                .scrollViews.children(matching: .other)
+                .element(boundBy: 0)
+                .children(matching: .other)
+                .element
+                .waitForExistence(timeout: 2)
+        )
+    }
+    
+    func uploadImage(task: String, image: String, comment: String) {
+        var takePhotoStaticText = staticTexts[task]
+        XCTAssertTrue(takePhotoStaticText.waitForExistence(timeout: 2))
+        takePhotoStaticText.tap()
+        
+        let addButton = images["Add"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 2))
+        addButton.tap()
+        
+        // Picks photo
+        XCTAssertTrue(buttons["Photo Picker"].waitForExistence(timeout: 2))
+        buttons["Photo Picker"].tap()
+        
+        XCTAssertTrue(images[image].waitForExistence(timeout: 2))
+        images[image].tap()
+        
+        // Enters a comment
+        textFields["Enter a comment (optional)"].tap()
+        textFields["Enter a comment (optional)"].typeText(comment)
+        
+        // Upload photo
+        buttons["Upload"].tap()
     }
 }

--- a/AllergyUITests/SchedulerAndQuestionnaireTests.swift
+++ b/AllergyUITests/SchedulerAndQuestionnaireTests.swift
@@ -28,8 +28,6 @@ class SchedulerAndQuestionnaireTests: XCTestCase {
         
         XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Schedule"].waitForExistence(timeout: 2))
         app.tabBars["Tab Bar"].buttons["Schedule"].tap()
-
-        XCTAssertTrue(app.staticTexts["Allergy Task"].waitForExistence(timeout: 2))
         
         XCTAssertTrue(app.staticTexts["Start Questionnaire"].waitForExistence(timeout: 2))
         app.staticTexts["Start Questionnaire"].tap()


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *UI-Tests for PhotoUpload, Scheduling, Questionnaire*

## :recycle: Lacked ui-tests for entire workflow

## :bulb: Proposed solution
Created ui-tests for basic photoupload workflow using the Photo picker option. We're unable to do this for the Camera and ARKit Camera because those options are not fully available on the 

## :gear: Release Notes 
*Add a summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented if it appends or changes the public interface.*

## :heavy_plus_sign: Additional Information
*Provide some additional information if possible*

### Related PRs
*Reference the related PRs*

### Testing
*Are there tests included? If yes, which situations are tested, and which corner cases are missing?*

### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

